### PR TITLE
하나의 메소드에 2개 이상의 Aspect Logic 수행 시 순서 지정

### DIFF
--- a/src/main/java/org/example/chap6/Main.java
+++ b/src/main/java/org/example/chap6/Main.java
@@ -21,9 +21,9 @@ public class Main {
         service.publishComment(comment);
 
         // 해당 메소드만 인터셉터하여 Aspect Logic 수행 후 메소드 호출
-        service.deleteComment(comment);
-
-        service.editComment(comment);
+//        service.deleteComment(comment);
+//
+//        service.editComment(comment);
 
     }
 

--- a/src/main/java/org/example/chap6/ProjectConfiguration.java
+++ b/src/main/java/org/example/chap6/ProjectConfiguration.java
@@ -1,6 +1,7 @@
 package org.example.chap6;
 
 import org.example.chap6.aspects.LoggingAspect;
+import org.example.chap6.aspects.SecurityAspect;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -21,8 +22,13 @@ public class ProjectConfiguration {
      * @return
      */
     @Bean
-    public LoggingAspect aspect() {
+    public LoggingAspect loggingAspect() {
         return new LoggingAspect();
+    }
+
+    @Bean
+    SecurityAspect securityAspect() {
+        return new SecurityAspect();
     }
 
 }

--- a/src/main/java/org/example/chap6/aspects/LoggingAspect.java
+++ b/src/main/java/org/example/chap6/aspects/LoggingAspect.java
@@ -95,16 +95,27 @@ public class LoggingAspect {
      * -> Object returnByMethod = joinPoint.proceed();를 수행하는 것과 동일한 역할을 수행
      * -> returning 속성에 대한 값으로 파라미터 변수명과 일치시켜야함
      */
-    @AfterReturning(
-            value = "@annotation(org.example.chap6.annotation.ToLog)",
-            returning = "returnedValue"
-    )
-    public void log(Object returnedValue) throws Throwable {
+//    @AfterReturning(
+//            value = "@annotation(org.example.chap6.annotation.ToLog)",
+//            returning = "returnedValue"
+//    )
+//    public void log(Object returnedValue) throws Throwable {
+//
+//        logger.info("Method executed and returned " + returnedValue);
+//
+//    }
 
-        logger.info("Method executed and returned " + returnedValue);
+    @Around(value = "@annotation(org.example.chap6.annotation.ToLog)")
+    public Object log(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        logger.info("Logging Aspect: Calling the intercepted method");
+
+        Object returnedValue = joinPoint.proceed();
+
+        logger.info("Logging Aspect: Method executed and returned " + returnedValue);
+
+        return returnedValue;
 
     }
-
-
 
 }

--- a/src/main/java/org/example/chap6/aspects/LoggingAspect.java
+++ b/src/main/java/org/example/chap6/aspects/LoggingAspect.java
@@ -1,14 +1,13 @@
 package org.example.chap6.aspects;
 
-import java.util.Arrays;
 import java.util.logging.Logger;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.example.chap6.Comment;
+import org.springframework.core.annotation.Order;
 
 @Aspect
+@Order(2)
 public class LoggingAspect {
 
     private Logger logger = Logger.getLogger(LoggingAspect.class.getName());

--- a/src/main/java/org/example/chap6/aspects/LoggingAspect.java
+++ b/src/main/java/org/example/chap6/aspects/LoggingAspect.java
@@ -3,6 +3,7 @@ package org.example.chap6.aspects;
 import java.util.Arrays;
 import java.util.logging.Logger;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.example.chap6.Comment;
@@ -69,24 +70,41 @@ public class LoggingAspect {
     /**
      * 사용자 정의 어노테이션을 통해 메소드를 인터셉터
      */
-    @Around("@annotation(org.example.chap6.annotation.ToLog)")
-    public Object log(ProceedingJoinPoint joinPoint) throws Throwable {
+//    @Around("@annotation(org.example.chap6.annotation.ToLog)")
+//    public Object log(ProceedingJoinPoint joinPoint) throws Throwable {
+//
+//        // 인터셉트한 메소드 이름 얻기
+//        String methodName = joinPoint.getSignature().getName();
+//
+//        // 인터셉트한 메소드의 매개변수 얻기
+//        Object[] arguments = joinPoint.getArgs();
+//
+//        logger.info("Method " + methodName + " with parameters " + Arrays.asList(arguments) + " will execute");
+//
+//        // 인터셉트 메소드 반환값 얻기
+//        Object returnByMethod = joinPoint.proceed();
+//
+//        logger.info("Method executed and returned " + returnByMethod);
+//
+//        return returnByMethod;
+//
+//    }
 
-        // 인터셉트한 메소드 이름 얻기
-        String methodName = joinPoint.getSignature().getName();
+    /**
+     * @AfterReturning : 인터셉트 메소드에서 반환된 값을 가져오기 위한 어노테이션
+     * -> Object returnByMethod = joinPoint.proceed();를 수행하는 것과 동일한 역할을 수행
+     * -> returning 속성에 대한 값으로 파라미터 변수명과 일치시켜야함
+     */
+    @AfterReturning(
+            value = "@annotation(org.example.chap6.annotation.ToLog)",
+            returning = "returnedValue"
+    )
+    public void log(Object returnedValue) throws Throwable {
 
-        // 인터셉트한 메소드의 매개변수 얻기
-        Object[] arguments = joinPoint.getArgs();
-
-        logger.info("Method " + methodName + " with parameters " + Arrays.asList(arguments) + " will execute");
-
-        // 인터셉트 메소드 반환값 얻기
-        Object returnByMethod = joinPoint.proceed();
-
-        logger.info("Method executed and returned " + returnByMethod);
-
-        return returnByMethod;
+        logger.info("Method executed and returned " + returnedValue);
 
     }
+
+
 
 }

--- a/src/main/java/org/example/chap6/aspects/SecurityAspect.java
+++ b/src/main/java/org/example/chap6/aspects/SecurityAspect.java
@@ -4,8 +4,14 @@ import java.util.logging.Logger;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
 
+/**
+ * @Order : Aspect 실행 순서를 정의하기 위한 어노테이션
+ * -> 작을수록 우선 수행
+ */
 @Aspect
+@Order(1)
 public class SecurityAspect {
 
     private Logger logger = Logger.getLogger(SecurityAspect.class.getName());

--- a/src/main/java/org/example/chap6/aspects/SecurityAspect.java
+++ b/src/main/java/org/example/chap6/aspects/SecurityAspect.java
@@ -1,0 +1,25 @@
+package org.example.chap6.aspects;
+
+import java.util.logging.Logger;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+@Aspect
+public class SecurityAspect {
+
+    private Logger logger = Logger.getLogger(SecurityAspect.class.getName());
+    @Around(value = "@annotation(org.example.chap6.annotation.ToLog)")
+    public Object security(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        logger.info("Security Aspect: Calling the intercepted method");
+
+        Object returnedValue = joinPoint.proceed();
+
+        logger.info("Security Aspect: Method executed and returned " + returnedValue);
+
+        return returnedValue;
+        
+    }
+
+}

--- a/src/main/java/org/example/chap6/services/CommentService.java
+++ b/src/main/java/org/example/chap6/services/CommentService.java
@@ -13,8 +13,10 @@ public class CommentService {
 
     private Logger logger = Logger.getLogger(CommentService.class.getName());
 
-    public void publishComment(Comment comment) {
+    @ToLog
+    public String publishComment(Comment comment) {
         logger.info("publish comment: " + comment.getText());
+        return "SUCCESS";
     }
 
     /**


### PR DESCRIPTION
## ✏️  What I learned today?
- @AfterReturning 어노테이션을 사용하여 인터셉터 메소드의 반환값을 Aspect 메소드 파라미터 변수값에 주입할 수 있음
- 기본적으로 Spring에서는 Aspect 호출 순서를 보장하지 못함
  - @Order(숫자) 어노테이션을 통해 어떤 Aspect를 먼저 수행할지 정의할 수 있음
    - 숫자가 작을수록 먼저 호출되어 실행되는 Aspect